### PR TITLE
Upgrade Junit to 4.13.2 to fix Vulnerability, Add plugin for Jitpack, remove Jcenter & Bintray configration

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,37 @@
+name: Run Tests, Build App
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - dev
+  push:
+    branches:
+      - master
+      - dev
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+
+    - name: Checkout Submodules
+      uses: actions/checkout@v3
+
+    - name: Validate Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
+
+    - name: Run Lint
+      run: ./gradlew lint --console plain
+
+    - name: Run Unit Tests
+      run: ./gradlew test --console plain
+
+    - name: Build Example App
+      run: ./gradlew :example:assembleRelease

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
 *.iml
+*.jks
+.DS_Store
+.externalNativeBuild
 .gradle
-/local.properties
 .idea/*
 /.idea/workspace.xml
 /.idea/libraries
-.DS_Store
 /build
 /captures
-.externalNativeBuild
 *.jks
+/local.properties

--- a/README.md
+++ b/README.md
@@ -8,24 +8,22 @@ Groupie lets you treat your content as logical groups and handles change notific
 
 # Try it out:
 
-[ ![Download](https://api.bintray.com/packages/lisawray/maven/groupie/images/download.svg) ](https://bintray.com/lisawray/maven/groupie/_latestVersion)
-
 ```gradle
-implementation "com.xwray:groupie:$groupie_version"
+implementation "com.github.legacybin.groupie:groupie:$groupie_version"
 ```
 
 Groupie includes a module for Kotlin and Kotlin Android extensions. Never write a ViewHolder again—Kotlin generates view references and Groupie uses a generic holder. [Setup here.](#kotlin) 
 
 ```gradle
-implementation "com.xwray:groupie:$groupie_version"
-implementation "com.xwray:groupie-kotlin-android-extensions:$groupie_version"
+implementation "com.github.legacybin.groupie:groupie:$groupie_version"
+implementation "com.github.legacybin.groupie:groupie-kotlin-android-extensions:$groupie_version"
 ```
 
 Groupie also has a support module for Android's [view binding](https://developer.android.com/topic/libraries/view-binding). This module also supports Android [data binding](https://developer.android.com/topic/libraries/data-binding/index.html), so if your project uses both data binding and view binding, you don't have to add the dependency on the data binding support module. [Setup here.](#view-binding)
 
 ```gradle
-implementation "com.xwray:groupie:$groupie_version"
-implementation "com.xwray:groupie-viewbinding:$groupie_version" 
+implementation "com.github.legacybin.groupie:groupie:$groupie_version"
+implementation "com.github.legacybin.groupie:groupie-viewbinding:$groupie_version" 
 ```
 
 ### Note:
@@ -34,8 +32,8 @@ If using `groupie-viewbinding` in a databinding project is only available when u
 If using an older Gradle Plugin version with databinding the you can use the standalone `groupie-databinding` library to generate view holders. [Setup here.](#data-binding) This is deprecated and will be removed in a future version in favour of only using `groupie-viewbinding`.
 
 ```gradle
-implementation "com.xwray:groupie:$groupie_version"
-implementation "com.xwray:groupie-databinding:$groupie_version" 
+implementation "com.github.legacybin.groupie:groupie:$groupie_version"
+implementation "com.github.legacybin.groupie:groupie-databinding:$groupie_version" 
 ```
 
 You can also use Groupie with Java and your existing ViewHolders. 
@@ -180,15 +178,36 @@ In your project level `build.gradle` file, include:
 
 ```
 buildscript {
-    ext.kotlin_version = '1.3.71'
+    ext.kotlin_version = '1.4.10'  //last version to support deprecated kotlin-android-extensions
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 ```
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
+    }
+}
+```
+In new projects, the `settings.gradle` file has a `dependencyResolutionManagement` block, which needs to specify the repository as well:
+```
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url 'https://jitpack.io' }  // <--
+        jcenter() // Warning: this repository is going to shut down soon
+    }
+}
+
 
 In your app `build.gradle` file, include:
 
@@ -209,8 +228,8 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'com.xwray:groupie:$groupie_version'
-    implementation 'com.xwray:groupie-kotlin-android-extensions:$groupie_version'
+    implementation 'com.github.legacybin.groupie:groupie:$groupie_version'
+    implementation 'com.github.legacybin.groupie:groupie-kotlin-android-extensions:$groupie_version'
 }
 ```
 
@@ -226,14 +245,14 @@ Add to your app module's `build.gradle`:
 
 ```gradle
 android {
-    viewBinding {
-        enabled = true
+    buildFeatures {
+        viewBinding = true
     }
 }
 
 dependencies {
-    implementation "com.xwray:groupie:$groupie_version"
-    implementation "com.xwray:groupie-viewbinding:$groupie_version"
+    implementation "com.github.legacybin.groupie:groupie:$groupie_version"
+    implementation "com.github.legacybin.groupie:groupie-viewbinding:$groupie_version"
 }
 ```
 
@@ -264,14 +283,14 @@ Add to your app module's build.gradle:
 
 ```gradle
 android {
-    dataBinding {
-        enabled = true
+    buildFeatures {
+        dataBinding = true
     }
 }
 
 dependencies {
-    implementation "com.xwray:groupie:$groupie_version"
-    implementation "com.xwray:groupie-databinding:$groupie_version"
+    implementation "com.github.legacybin.groupie:groupie:$groupie_version"
+    implementation "com.github.legacybin.groupie:groupie-databinding:$groupie_version"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,12 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:$android_plugin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18"
 
@@ -36,9 +36,9 @@ buildscript {
 allprojects { project ->
 
     repositories {
-        maven { url 'https://dl.bintray.com/lisawray/maven' }
         google()
-        jcenter()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
     }
 
     afterEvaluate {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     ext.databinding_version = '4.0.1'
     ext.viewbinding_version = '4.0.1'
 
-    ext.junit_version = '4.13'
+    ext.junit_version = '4.13.2'
     ext.mockito_version = '3.3.3'
 
     repositories {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -4,7 +4,8 @@ apply plugin: 'kotlin-android-extensions'
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -45,4 +46,6 @@ dependencies {
 
 repositories {
     mavenCentral()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,9 @@
+jdk:
+  - openjdk11
+
+before_install:
+  - source "$HOME/.sdkman/bin/sdkman-init.sh"
+  - sdk update
+  - sdk install java 11.0.2.9-tem
+  - sdk use java 11.0.2.9-tem
+  - sdk default java 11.0.2.9-tem

--- a/library-databinding/build.gradle
+++ b/library-databinding/build.gradle
@@ -2,7 +2,8 @@ apply plugin: 'com.android.library'
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
     }
 }
 
@@ -47,6 +48,4 @@ dependencies {
     }
     compileOnly("androidx.annotation:annotation:1.1.0")
 }
-
-apply from: rootProject.file('release-bintray.gradle')
 

--- a/library-kotlin-android-extensions/build.gradle
+++ b/library-kotlin-android-extensions/build.gradle
@@ -4,7 +4,8 @@ apply plugin: 'kotlin-android-extensions'
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -58,5 +59,3 @@ repositories {
 tasks.withType(Javadoc).all {
     enabled = false
 }
-
-apply from: rootProject.file('release-bintray.gradle')

--- a/library-viewbinding/build.gradle
+++ b/library-viewbinding/build.gradle
@@ -2,7 +2,8 @@ apply plugin: 'com.android.library'
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
     }
 }
 
@@ -41,6 +42,4 @@ dependencies {
     }
     compileOnly("androidx.annotation:annotation:1.1.0")
 }
-
-apply from: rootProject.file('release-bintray.gradle')
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,8 @@ apply plugin: 'com.android.library'
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
     }
 }
 
@@ -38,5 +39,3 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
     testImplementation "org.mockito:mockito-core:$mockito_version"
 }
-
-apply from: rootProject.file('release-bintray.gradle')

--- a/release-bintray.gradle
+++ b/release-bintray.gradle
@@ -29,5 +29,3 @@ ext {
 // Set up the Android Maven publication.
 apply from: rootProject.file('jcenter/maven-install.gradle')
 
-// Publish on Bintray.
-apply from: rootProject.file('jcenter/bintray.gradle')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':example-databinding', ':library-databinding', ':library', ':example', ':example-shared', ':library-kotlin-android-extensions', 'example-viewbinding', ':library-viewbinding'
+include ':example-databinding', ':library-databinding', ':library', ':example', ':example-shared', ':library-kotlin-android-extensions', ':example-viewbinding', ':library-viewbinding'


### PR DESCRIPTION
Upgrade Junit to 4.13.2 to fix Vulnerability
vulnerability was found here:
https://mvnrepository.com/artifact/com.xwray/groupie/2.9.0
Also
Update kotlin to 1.4.10 , gradle plugin version to 4.1.3 & gradle wrapper to 6.9
Update databinding and viewbinding docs to use new buildFeatures
Sort .gitignore to be in a consistent order